### PR TITLE
Make the client thread-safe

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -9,7 +9,7 @@ use crate::{config::Config, error::Result};
 pub mod client;
 
 #[maybe_async]
-pub trait HttpClient: DynClone + std::fmt::Debug {
+pub trait HttpClient: DynClone + Send + Sync + std::fmt::Debug {
     fn try_from(config: Config) -> Result<Self>
     where
         Self: Sized;


### PR DESCRIPTION
Allows the client to be used in threaded environments.

reqwest::Client is still compatible with this change, but if people are using some other http client this is potentially a breaking change. Might want to do a minor release before this one.