### PR TITLE
Implement BankID Api v6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -116,11 +116,13 @@ dependencies = [
  "dyn-clone",
  "env_logger",
  "futures",
+ "hex",
  "maybe-async",
  "openssl",
  "pem",
  "rand",
  "reqwest",
+ "ring",
  "serde",
  "serde_json",
  "thiserror",
@@ -149,9 +151,9 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "bytes"
@@ -161,12 +163,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
 
 [[package]]
 name = "cfg-if"
@@ -198,9 +197,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "darling"
-version = "0.20.6"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c376d08ea6aa96aafe61237c7200d1241cb177b7d3a542d791f2d118e9cbb955"
+checksum = "3a5d17510e4a1a87f323de70b7b1eaac1ee0e37866c6720b2d279452d0edf389"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -208,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.6"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33043dcd19068b8192064c704b3f83eb464f91f1ff527b44a4e2b08d9cdb8855"
+checksum = "a98eea36a7ff910fa751413d0895551143a8ea41d695d9798ec7d665df7f7f5e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -222,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.6"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a91391accf613803c2a9bf9abccdbaa07c54b4244a5b64883f9c3c137c86be"
+checksum = "d6a366a3f90c5d59a4b91169775f88e52e8f71a0e7804cc98a8db2932cf4ed57"
 dependencies = [
  "darling_core",
  "quote",
@@ -491,9 +490,15 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -590,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -773,9 +778,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.100"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae94056a791d0e1217d18b6cbdccb02c61e3054fc69893607f4067e3bb0b1fd1"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -836,9 +841,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"
@@ -974,6 +979,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,15 +1023,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a716eb65e3158e90e17cd93d855216e27bde02745ab842f2cab4a39dba1bacf"
+checksum = "048a63e5b3ac996d78d402940b5fa47973d2d080c6c6fffa1d0f19c4445310b7"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "schannel"
@@ -1120,13 +1140,19 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -1136,9 +1162,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1330,12 +1356,18 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1475,7 +1507,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -1495,17 +1527,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
 
 [[package]]
@@ -1516,9 +1548,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1528,9 +1560,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1540,9 +1572,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1552,9 +1584,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1564,9 +1596,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1576,9 +1608,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1588,9 +1620,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ pem = "3.0.3"
 openssl = { version = "0.10.64", optional = true }
 webpki-roots = "0.26.1"
 dyn-clone = "1.0.4"
+ring = "0.17.7"
+hex = "0.4.3"
 
 [dev-dependencies]
 env_logger = "0.11.2"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # BankID-rs
 
-BankID-rs is a BankID SDK. It includes support for all the v5.1 features.
+BankID-rs is a BankID SDK. It includes support for all the v6.0 features except /phone.
 
 To learn how to use BankID-rs, please refer to the [documentation](https://docs.rs/crate/bankid-rs/). There are some [examples that may be useful](./examples) as well.
 

--- a/examples/authenticate.rs
+++ b/examples/authenticate.rs
@@ -1,26 +1,31 @@
+use bankid::config::{API_URL_TEST, CA_TEST};
 use bankid::{
     client::BankID,
     config::{ConfigBuilder, Pkcs12},
     model::{AuthenticatePayloadBuilder, CancelPayload, CollectPayload},
 };
-use bankid::config::CA_TEST;
 
 #[tokio::main]
 async fn main() {
     let bank_id = client();
 
     let payload = AuthenticatePayloadBuilder::default()
-        .personal_number("123456789123".to_string())
         .end_user_ip("123.123.123.123".to_string())
         .build()
         .unwrap();
 
     let authenticate = &bank_id.authenticate(payload).await.unwrap();
-    let collect = bank_id.collect(CollectPayload { order_ref: authenticate.clone().order_ref })
+    let collect = bank_id
+        .collect(CollectPayload {
+            order_ref: authenticate.clone().order_ref,
+        })
         .await
         .unwrap();
 
-    let cancel = bank_id.cancel(CancelPayload { order_ref: authenticate.clone().order_ref })
+    let cancel = bank_id
+        .cancel(CancelPayload {
+            order_ref: authenticate.clone().order_ref,
+        })
         .await
         .unwrap();
 
@@ -37,7 +42,7 @@ fn client() -> BankID {
 
     let config = ConfigBuilder::default()
         .pkcs12(pkcs12)
-        .url("https://appapi2.test.bankid.com/rp/v5.1".to_string())
+        .url(API_URL_TEST.to_string())
         .ca(CA_TEST.to_string())
         .build()
         .unwrap();
@@ -45,4 +50,4 @@ fn client() -> BankID {
     BankID::new(config)
 }
 
-const P12_TEST: &'static [u8] = include_bytes!("../resources/testcert.p12");
+const P12_TEST: &[u8] = include_bytes!("../resources/testcert.p12");

--- a/examples/sign.rs
+++ b/examples/sign.rs
@@ -1,27 +1,34 @@
+use bankid::config::{API_URL_TEST, CA_TEST};
 use bankid::{
     client::BankID,
     config::{ConfigBuilder, Pkcs12},
     model::{CancelPayload, CollectPayload, SignPayloadBuilder},
 };
-use bankid::config::CA_TEST;
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
 
 #[tokio::main]
 async fn main() {
     let bank_id = client();
 
     let payload = SignPayloadBuilder::default()
-        .personal_number("123456789123".to_string())
         .end_user_ip("123.123.123.123".to_string())
-        .user_visible_data(base64::encode("Hello"))
+        .user_visible_data(STANDARD.encode(b"Hello"))
         .build()
         .unwrap();
 
     let sign = bank_id.sign(payload).await.unwrap();
-    let collect = bank_id.collect(CollectPayload { order_ref: sign.clone().order_ref })
+    let collect = bank_id
+        .collect(CollectPayload {
+            order_ref: sign.clone().order_ref,
+        })
         .await
         .unwrap();
 
-    let cancel = bank_id.cancel(CancelPayload { order_ref: sign.clone().order_ref })
+    let cancel = bank_id
+        .cancel(CancelPayload {
+            order_ref: sign.clone().order_ref,
+        })
         .await
         .unwrap();
 
@@ -38,7 +45,7 @@ fn client() -> BankID {
 
     let config = ConfigBuilder::default()
         .pkcs12(pkcs12)
-        .url("https://appapi2.test.bankid.com/rp/v5.1".to_string())
+        .url(API_URL_TEST.to_string())
         .ca(CA_TEST.to_string())
         .build()
         .unwrap();
@@ -46,4 +53,4 @@ fn client() -> BankID {
     BankID::new(config)
 }
 
-const P12_TEST: &'static [u8] = include_bytes!("../resources/testcert.p12");
+const P12_TEST: &[u8] = include_bytes!("../resources/testcert.p12");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.75"
+components = ["rust-analyzer", "rustfmt"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,13 +1,10 @@
 overflow_delimited_expr = true
 newline_style = "Unix"
-imports_granularity="Crate"
+imports_granularity = "Crate"
 reorder_impl_items = true
 fn_single_line = false
 blank_lines_upper_bound = 2
-ignore = [
-    "examples/",
-    "tests/"
-]
+ignore = ["examples/", "tests/"]
 comment_width = 120
 max_width = 120
 inline_attribute_width = 120

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -74,9 +74,9 @@ impl TryFrom<Config> for reqwest::blocking::ClientBuilder {
 }
 
 #[allow(dead_code)]
-pub const API_URL_TEST: &str = "https://appapi2.test.bankid.com/rp/v5.1";
+pub const API_URL_TEST: &str = "https://appapi2.test.bankid.com/rp/v6.0";
 #[allow(dead_code)]
-pub const API_URL_PROD: &str = "https://appapi2.bankid.com/rp/v5.1";
+pub const API_URL_PROD: &str = "https://appapi2.bankid.com/rp/v6.0";
 
 #[allow(dead_code)]
 pub const CA_TEST: &str = include_str!("../../resources/test.ca");

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -43,7 +43,7 @@ impl HttpClient for Client {
 
     #[inline]
     async fn post(&self, url: &str, payload: &Value) -> Result<String> {
-        let mut request = self.inner.request(Method::POST, &self.endpoint_url(url));
+        let mut request = self.inner.request(Method::POST, self.endpoint_url(url));
         request = request.json(payload);
 
         let response = request.send().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Crate for interacting with the BankID API.
 //!
-//! This crate includes tools for interacting with the BankID API v5.1.
+//! This crate includes tools for interacting with the BankID API v6.0.
 //!
 //! The crate support asynchronous paradigm with `async` and `await` by leveraging `reqwest` crate.
 //!
@@ -44,4 +44,5 @@ pub mod config;
 pub mod error;
 mod http;
 pub mod model;
+pub mod qr;
 mod tls;

--- a/src/model/authenticate.rs
+++ b/src/model/authenticate.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::Requirement;
 
+use super::UserVisibleDataFormat;
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Authenticate {
@@ -20,10 +22,6 @@ pub struct Authenticate {
 #[serde(rename_all = "camelCase")]
 #[builder(setter(strip_option))]
 pub struct AuthenticatePayload {
-    /// The personal number of the user. String. 12 digits. Century must be included.
-    /// If the personal number is excluded, the client must be started with the
-    /// autoStartToken returned in the response
-    pub personal_number: Option<String>,
     /// The user IP address as seen by RP. String. IPv4 and IPv6 is allowed.
     /// Note the importance of using the correct IP address. It must be the IP address
     /// representing the user agent (the end user device) as seen by the RP. If there is a
@@ -32,8 +30,29 @@ pub struct AuthenticatePayload {
     /// voice based services. In this case, the internal representation of those systems IP
     /// address is ok to use
     pub end_user_ip: String,
-    /// Requirements on how the auth or sign order must be performed
+    /// Requirements on how the auth order must be performed.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "Option::None")]
     pub requirement: Option<Requirement>,
+    /// Text displayed to the user during authentication with BankID,
+    /// with the purpose of providing context for the authentication and
+    /// to enable users to detect identification errors and averting fraud attempts.
+    /// The text can be formatted using CR, LF and CRLF for new lines.
+    /// The text must be encoded as UTF-8 and then base 64 encoded.
+    /// 1—1 500 characters after base 64 encoding.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default = "Option::None")]
+    pub user_visible_data: Option<String>,
+    /// Data not displayed to the user. String. The value must be base 64-encoded.
+    /// 1-1 500 characters after base 64-encoding.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default = "Option::None")]
+    pub user_non_visible_data: Option<String>,
+    /// If present, and set to “simpleMarkdownV1”, this parameter indicates that
+    /// userVisibleData holds formatting characters which, if used correctly, will make
+    /// the text displayed with the user nicer to look at. For further information of
+    /// formatting options, please study the document Guidelines for Formatted Text.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default = "Option::None")]
+    pub user_visible_data_format: Option<UserVisibleDataFormat>,
 }

--- a/src/model/collect.rs
+++ b/src/model/collect.rs
@@ -1,6 +1,33 @@
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum Status {
+    Pending,
+    Complete,
+    Failed,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum HintCode {
+    // Pending
+    OutstandingTransaction,
+    NoClient,
+    Started,
+    UserMRTD,
+    UserCallConfirm,
+    UserSign,
+    // Failed
+    ExpiredTransaction,
+    CertificateErr,
+    UserCancel,
+    Cancelled,
+    StartFailed,
+    UserDeclinedCall,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Builder)]
 #[serde(rename_all = "camelCase")]
 #[builder(setter(strip_option))]
@@ -13,9 +40,9 @@ pub struct Collect {
     /// pending - The order is being processed. hintCode describes the status of the order.
     /// failed - Something went wrong with the order. hintCode describes the error.
     /// complete - The order is complete. completionData holds user information.
-    pub status: String,
+    pub status: Status,
     /// Describes the status of the order.
-    pub hint_code: String,
+    pub hint_code: Option<HintCode>,
     /// Only present for complete orders.
     pub completion_data: Option<CompletionData>,
 }
@@ -31,41 +58,47 @@ pub struct CollectPayload {
 #[serde(rename_all = "camelCase")]
 pub struct CompletionData {
     /// Information related to the user.
-    user: User,
+    pub user: User,
     /// Information related to the device.
-    device: Device,
-    /// Information related to the user’s certificate.
-    cert: Cert,
+    pub device: Device,
+    /// The date the BankID was issued to the user.
+    pub bank_id_issue_date: String,
+    /// Information about extra verifications that were part of the transaction.
+    /// mrtd: Indicate if there was a check of the mrtd (machine readable travel document).
+    /// True if the mrtd check was performed and passed.
+    pub step_up: Option<bool>,
     /// The signature. Base64-encoded
-    signature: String,
-    ocsp_response: String,
+    pub signature: String,
+    pub ocsp_response: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Builder)]
 #[serde(rename_all = "camelCase")]
 pub struct User {
     /// The personal number
-    personal_number: String,
+    pub personal_number: String,
     /// The given name and surname of the user
-    name: String,
+    pub name: String,
     /// The given name of the user.
-    given_name: String,
+    pub given_name: String,
     /// The surname of the user.
-    surname: String,
+    pub surname: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Builder)]
 #[serde(rename_all = "camelCase")]
 pub struct Device {
     /// The IP address of the user agent as the BankID server discovers it
-    ip_address: String,
+    pub ip_address: String,
+    /// Unique hardware identifier for the user’s device.
+    pub uhi: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Builder)]
 #[serde(rename_all = "camelCase")]
 pub struct Cert {
     ///  Start of validity of the users BankID
-    not_before: String,
+    pub not_before: String,
     /// End of validity of the Users BankID
-    not_after: String,
+    pub not_after: String,
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -13,30 +13,45 @@ pub mod cancel;
 pub mod collect;
 pub mod sign;
 
-/// Requirement restricts the type of BankID that can be used as well as other requirements.
-///
-/// # Notice
-/// If personal number is included in the call to the service, RP must
-/// consider setting the requirement tokenStartRequired to true. By this, the
-/// system enforces that no other device than the one started using the QR code
-/// or autostarttoken is used.
+/// RP may use the requirement parameter to describe how a signature must be created and verified.
+/// A typical use case is to require Mobile BankID or a certain card reader.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Builder, Default)]
 #[serde(rename_all = "camelCase")]
 #[builder(setter(strip_option))]
 pub struct Requirement {
+    /// Users are required to sign the transaction with their PIN code, even if they have biometrics activated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default = "Option::None")]
+    pub pin_code: Option<bool>,
+    /// If present, and set to "true",
+    /// the client needs to provide MRTD (Machine readable travel document) information to complete the order.
+    /// Only Swedish passports and national ID cards are supported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default = "Option::None")]
+    pub mrtd: Option<bool>,
+    /// "class1" (default) – The transaction must be performed using a card reader where the PIN code is entered
+    /// on a computer keyboard, or a card reader of higher class.
+    /// "class2" – The transaction must be performed using a card reader where the PIN code is entered on the reader,
+    /// or a reader of higher class.
+    /// "<"no value">" – defaults to "class1". This condition should be combined with a certificatePolicies
+    /// for a smart card to avoid undefined behaviour.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "Option::None")]
     pub card_reader: Option<String>,
+    /// The oid in certificate policies in the user certificate.
+    /// One wildcard ”” is allowed from position 5 and forward ie. 1.2.752.78.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[builder(default = "vec!()")]
     pub certificate_policies: Vec<String>,
+    /// A personal identification number to be used to complete the transaction.
+    /// If a BankID with another personal number attempts to sign the transaction, it fails.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "Option::None")]
-    pub issuer_cn: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default = "Option::None")]
-    pub auto_start_token_required: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default = "Option::None")]
-    pub allow_fingerprint: Option<bool>,
+    pub personal_number: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub enum UserVisibleDataFormat {
+    #[serde(rename = "simpleMarkdownV1")]
+    SimpleMarkdownV1,
 }

--- a/src/model/sign.rs
+++ b/src/model/sign.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::Requirement;
 
+use super::UserVisibleDataFormat;
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Sign {
@@ -20,10 +22,6 @@ pub struct Sign {
 #[serde(rename_all = "camelCase")]
 #[builder(setter(strip_option))]
 pub struct SignPayload {
-    /// The personal number of the user. String. 12 digits. Century must be included.
-    /// If the personal number is excluded, the client must be started with the
-    /// autoStartToken returned in the response
-    pub personal_number: Option<String>,
     /// The user IP address as seen by RP. String. IPv4 and IPv6 is allowed.
     /// Note the importance of using the correct IP address. It must be the IP address
     /// representing the user agent (the end user device) as seen by the RP. If there is a
@@ -34,10 +32,10 @@ pub struct SignPayload {
     pub end_user_ip: String,
     /// The text to be displayed and signed. String. The text can be formatted using CR,
     /// LF and CRLF for new lines. The text must be encoded as UTF-8 and then base 64
-    /// encoded. 1--40 000 characters after base 64 encoding.
+    /// encoded. 1-40 000 characters after base 64 encoding.
     pub user_visible_data: String,
-    /// Data not displayed to the user. String. The value must be base 64-encoded. 1-200
-    /// 000 characters after base 64-encoding.
+    /// Data not displayed to the user. String. The value must be base 64-encoded.
+    /// 1-200 000 characters after base 64-encoding.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "Option::None")]
     pub user_non_visible_data: Option<String>,
@@ -51,10 +49,4 @@ pub struct SignPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default = "Option::None")]
     pub requirement: Option<Requirement>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
-pub enum UserVisibleDataFormat {
-    #[serde(rename = "simpleMarkdownV1")]
-    SimpleMarkdownV1,
 }

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -1,0 +1,31 @@
+use crate::error::Error;
+use ring::hmac::{sign, Key, HMAC_SHA256};
+
+pub fn generate_qr_code_data(qr_start_token: &str, qr_start_secret: &str, seconds: usize) -> Result<String, Error> {
+    let hmac_key = Key::new(HMAC_SHA256, qr_start_secret.as_bytes());
+    let sig = sign(&hmac_key, format!("{}", seconds).as_bytes());
+    let res = format!("bankid.{}.{}.{}", qr_start_token, seconds, hex::encode(sig));
+    Ok(res)
+}
+
+#[test]
+fn test_qr_0() {
+    let res = generate_qr_code_data(
+        "67df3917-fa0d-44e5-b327-edcc928297f8",
+        "d28db9a7-4cde-429e-a983-359be676944c",
+        0,
+    )
+    .unwrap();
+    assert_eq!(res, "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.0.dc69358e712458a66a7525beef148ae8526b1c71610eff2c16cdffb4cdac9bf8".to_string())
+}
+
+#[test]
+fn test_qr_1() {
+    let res = generate_qr_code_data(
+        "67df3917-fa0d-44e5-b327-edcc928297f8",
+        "d28db9a7-4cde-429e-a983-359be676944c",
+        1,
+    )
+    .unwrap();
+    assert_eq!(res, "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.1.949d559bf23403952a94d103e67743126381eda00f0b3cbddbf7c96b1adcbce2".to_string())
+}

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -52,7 +52,7 @@ impl Certificate {
     #[allow(dead_code)]
     pub fn from_string(subject: &str) -> Result<Vec<reqwest::Certificate>> {
         let buf: Vec<u8> = subject.into();
-        let pems = pem::parse_many(&buf).map_err(|source| Error::PemError { source })?;
+        let pems = pem::parse_many(buf).map_err(|source| Error::PemError { source })?;
 
         pems.into_iter()
             .map(|pem| {

--- a/tests/test_models.rs
+++ b/tests/test_models.rs
@@ -4,7 +4,7 @@ use bankid::model::*;
 fn test_authenticate() {
     let json_str = r#"{"orderRef":"1b9839fe-9b79-4b71-8534-618f4c7ea12b","autoStartToken":"f70c5c18-9a0c-4299-93b8-ed7b0fc4bb0d","qrStartToken":"82a40faa-9cb1-4acc-a7fd-bd76b0aaf6c6","qrStartSecret":"843050ed-0a4c-4135-b33c-acc08783a61b"}"#;
 
-    let authenticate: Authenticate = serde_json::from_str(&json_str).unwrap();
+    let authenticate: Authenticate = serde_json::from_str(json_str).unwrap();
 
     assert_eq!(
         "1b9839fe-9b79-4b71-8534-618f4c7ea12b".to_string(),


### PR DESCRIPTION
# BREAKING CHANGE

* Implements RP API v6 and removes support for earlier versions.
* Adds a qr code data generator
* status and hintCode fields are now enums

`/phone/auth` and `/phone/sign` is not implemented yet.

Closes  #183