### PR TITLE
Add release github workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+on:
+  release:
+    types:
+      - created
+name: release
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Publish on creates.io
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        with:
+          command: publish
+          args: --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "bankid"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bankid"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Nicklas Wallgren <nicklas.wallgren@gmail.com>", "Daniel L <https://github.com/dlq84>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
A simple github workflow which publishes new releases to crates.io

The workflow is untested.

Fixes https://github.com/e-identification/bankid-rs/issues/201